### PR TITLE
게시판 페이지네이션 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
 import { useEffect, useState } from 'react';
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { MemoryRouter } from 'react-router-dom';
 

--- a/src/components/CategoryPosts.jsx
+++ b/src/components/CategoryPosts.jsx
@@ -30,9 +30,22 @@ const PostImage = styled.img`
 
 export default function CategoryPosts({
   posts, commentNumber, recommentNumber, likes, users, categories, navigate, categoryId,
+  changePageNumber, nextPage, previousPage, pageButtons, isPreviousPage, isNextPage,
 }) {
   const handleClickPost = (id) => {
     navigate(`/post/${id}`);
+  };
+
+  const handleClickPage = (event) => {
+    changePageNumber(event.target.innerText - 1);
+  };
+
+  const handleClickNextPage = () => {
+    nextPage();
+  };
+
+  const handleClickPreviousPage = () => {
+    previousPage();
   };
 
   return (
@@ -90,6 +103,23 @@ export default function CategoryPosts({
               ))}
             </List>
           </article>
+          <div>
+            {isPreviousPage ? (
+              <button type="button" onClick={handleClickPreviousPage}>이전</button>
+            ) : null}
+            {pageButtons.map((pageButton) => (
+              <button
+                key={pageButton}
+                type="button"
+                onClick={(event) => handleClickPage(event)}
+              >
+                {pageButton}
+              </button>
+            ))}
+            {isNextPage ? (
+              <button type="button" onClick={handleClickNextPage}>다음</button>
+            ) : null}
+          </div>
         </section>
       )}
     </div>

--- a/src/components/CategoryPosts.test.jsx
+++ b/src/components/CategoryPosts.test.jsx
@@ -3,6 +3,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import CategoryPosts from './CategoryPosts';
 
 const navigate = jest.fn();
+const changePageNumber = jest.fn();
+const nextPage = jest.fn();
+const previousPage = jest.fn();
 
 const context = describe;
 
@@ -52,6 +55,12 @@ describe('CategoryPosts', () => {
 
     const recommentNumber = [1, 1, 1];
 
+    const pageButtons = [1, 2, 3];
+
+    const isPreviousPage = false;
+
+    const isNextPage = true;
+
     const categoryId = 1;
 
     render(<CategoryPosts
@@ -63,6 +72,12 @@ describe('CategoryPosts', () => {
       categories={categories}
       navigate={navigate}
       categoryId={categoryId}
+      changePageNumber={changePageNumber}
+      nextPage={nextPage}
+      previousPage={previousPage}
+      pageButtons={pageButtons}
+      isPreviousPage={isPreviousPage}
+      isNextPage={isNextPage}
     />);
   });
 
@@ -83,6 +98,30 @@ describe('CategoryPosts', () => {
       fireEvent.click(screen.getByText('이강인 맨시티 이적...!! [7]'));
 
       expect(navigate).toBeCalled();
+    });
+  });
+
+  it('render page buttons', () => {
+    screen.getByText('1');
+    screen.getByText('2');
+    screen.getByText('3');
+  });
+
+  it('render next page button', () => {
+    screen.getByText('다음');
+  });
+
+  context('when click page button', () => {
+    it('next page function call', () => {
+      fireEvent.click(screen.getByText('다음'));
+
+      expect(nextPage).toBeCalled();
+    });
+
+    it('changePageNumber function call', () => {
+      fireEvent.click(screen.getByText('3'));
+
+      expect(changePageNumber).toBeCalled();
     });
   });
 });

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+
 import { Link } from 'react-router-dom';
+
 import Menu from './Menu';
 
 export default function Header() {
@@ -8,6 +10,7 @@ export default function Header() {
   const handleClickMenu = () => {
     setIsShow(!isShow);
   };
+
   return (
     <div>
       <nav>

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,24 +1,34 @@
 import { Link } from 'react-router-dom';
 
+import { postStore } from '../stores/PostStore';
+
 export default function Menu() {
+  const handleClickTotalBoard = () => {
+    postStore.changePageNumber(0);
+  };
+
+  const handleClickCategory = () => {
+    postStore.pageNumber = 0;
+  };
+
   return (
     <div>
       <nav>
         <ul>
           <li>
-            <Link to="/">전체 게시판</Link>
+            <Link to="/" onClick={handleClickTotalBoard}>전체 게시판</Link>
           </li>
           <li>
-            <Link to="/posts?category=2">EPL</Link>
+            <Link to="/posts?category=2" onClick={handleClickCategory}>EPL</Link>
           </li>
           <li>
-            <Link to="/posts?category=3">LaLiga</Link>
+            <Link to="/posts?category=3" onClick={handleClickCategory}>LaLiga</Link>
           </li>
           <li>
-            <Link to="/posts?category=4">SerieA</Link>
+            <Link to="/posts?category=4" onClick={handleClickCategory}>SerieA</Link>
           </li>
           <li>
-            <Link to="/posts?category=5">Bundesliga</Link>
+            <Link to="/posts?category=5" onClick={handleClickCategory}>Bundesliga</Link>
           </li>
         </ul>
       </nav>

--- a/src/components/Posts.jsx
+++ b/src/components/Posts.jsx
@@ -54,6 +54,7 @@ const WriteButton = styled.button`
 
 export default function Posts({
   posts, commentNumber, recommentNumber, likes, users, categories, navigate,
+  changePageNumber, nextPage, previousPage, pageButtons, isPreviousPage, isNextPage,
 }) {
   const handleClickPost = (id) => {
     navigate(`/post/${id}`);
@@ -67,10 +68,22 @@ export default function Posts({
     navigate('/schedule');
   };
 
+  const handleClickPage = (event) => {
+    changePageNumber(event.target.innerText - 1);
+  };
+
+  const handleClickNextPage = () => {
+    nextPage();
+  };
+
+  const handleClickPreviousPage = () => {
+    previousPage();
+  };
+
   return (
     <Container>
       {Object.keys(posts).length === 0 ? (
-        <p>loading</p>
+        <p>게시글이 없습니다.</p>
       ) : (
         <section>
           <div>
@@ -123,6 +136,23 @@ export default function Posts({
               ))}
             </List>
           </article>
+          <div>
+            {isPreviousPage ? (
+              <button type="button" onClick={handleClickPreviousPage}>이전</button>
+            ) : null}
+            {pageButtons.map((pageButton) => (
+              <button
+                key={pageButton}
+                type="button"
+                onClick={(event) => handleClickPage(event)}
+              >
+                {pageButton}
+              </button>
+            ))}
+            {isNextPage ? (
+              <button type="button" onClick={handleClickNextPage}>다음</button>
+            ) : null}
+          </div>
         </section>
       )}
     </Container>

--- a/src/components/Posts.test.jsx
+++ b/src/components/Posts.test.jsx
@@ -3,6 +3,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import Posts from './Posts';
 
 const navigate = jest.fn();
+const changePageNumber = jest.fn();
+const nextPage = jest.fn();
+const previousPage = jest.fn();
 
 describe('posts', () => {
   beforeEach(() => {
@@ -46,6 +49,12 @@ describe('posts', () => {
 
     const recommentNumber = [1, 1, 1];
 
+    const pageButtons = [1, 2, 3, 4, 5];
+
+    const isPreviousPage = false;
+
+    const isNextPage = true;
+
     render(<Posts
       posts={posts}
       commentNumber={commentNumber}
@@ -54,6 +63,12 @@ describe('posts', () => {
       users={users}
       categories={categories}
       navigate={navigate}
+      changePageNumber={changePageNumber}
+      nextPage={nextPage}
+      previousPage={previousPage}
+      pageButtons={pageButtons}
+      isPreviousPage={isPreviousPage}
+      isNextPage={isNextPage}
     />);
   });
 
@@ -73,5 +88,29 @@ describe('posts', () => {
     fireEvent.click(screen.getByText('대한민국 카타르 월드컵 4강 진출 [7]'));
 
     expect(navigate).toBeCalledWith('/post/1');
+  });
+
+  it('render page buttons', () => {
+    screen.getByText('1');
+    screen.getByText('2');
+    screen.getByText('3');
+    screen.getByText('4');
+    screen.getByText('5');
+  });
+
+  it('click next page button', () => {
+    fireEvent.click(screen.getByText('다음'));
+
+    expect(nextPage).toBeCalled();
+  });
+
+  it('click page button', () => {
+    fireEvent.click(screen.getByText('1'));
+
+    expect(changePageNumber).toBeCalled();
+  });
+
+  it('render next page button', () => {
+    screen.getByText('다음');
   });
 });

--- a/src/pages/CategoryPostsPage.jsx
+++ b/src/pages/CategoryPostsPage.jsx
@@ -25,20 +25,41 @@ export default function CategoryPostsPage() {
 
   const navigate = useNavigate();
 
+  const { pageNumber } = postStore;
+
   useEffect(() => {
-    postStore.fetchCategoryPosts(categoryId);
+    postStore.fetchCategoryPosts(categoryId, pageNumber);
     commentStore.fetchComments();
     commentStore.fetchRecomments();
     userStore.fetchUsers();
     likeStore.fetchLike();
     categoryStore.fetchCategory();
-  }, [location]);
+  }, [location, pageNumber]);
+
+  const changePageNumber = (pageNubmer) => {
+    postStore.changePageNumber(pageNubmer);
+  };
+
+  const nextPage = () => {
+    postStore.nextPage();
+  };
+
+  const previousPage = () => {
+    postStore.previousPage();
+  };
 
   const { comments } = commentStore;
   const { recomments } = commentStore;
 
   const commentNumber = comments.map((comment) => comment.postId);
   const recommentNumber = recomments.map((recomment) => recomment.postId);
+
+  const { startPage } = postStore.page;
+  const { lastPage } = postStore.page;
+  const { currentLastPage } = postStore.page;
+
+  const isPreviousPage = startPage > 1;
+  const isNextPage = lastPage < currentLastPage;
 
   return (
     <CategoryPosts
@@ -50,6 +71,12 @@ export default function CategoryPostsPage() {
       categories={categoryStore.categories}
       navigate={navigate}
       categoryId={categoryId}
+      changePageNumber={changePageNumber}
+      nextPage={nextPage}
+      previousPage={previousPage}
+      pageButtons={postStore.pageButton}
+      isPreviousPage={isPreviousPage}
+      isNextPage={isNextPage}
     />
   );
 }

--- a/src/pages/CategoryPostsPage.test.jsx
+++ b/src/pages/CategoryPostsPage.test.jsx
@@ -10,6 +10,11 @@ const fetchLike = jest.fn();
 
 const navigate = jest.fn();
 
+const makePage = jest.fn();
+const changePageNumber = jest.fn();
+const nextPage = jest.fn();
+const previousPage = jest.fn();
+
 let location = {};
 
 let posts = [];
@@ -19,9 +24,18 @@ let categories = [];
 let comments = [];
 let recomments = [];
 
+let page = {};
+let pageButton = [];
+
 jest.mock('../hooks/usePostStore', () => () => ({
   fetchCategoryPosts,
   posts,
+  makePage,
+  changePageNumber,
+  nextPage,
+  previousPage,
+  page,
+  pageButton,
 }));
 
 jest.mock('../hooks/useCommentStore', () => () => ({
@@ -122,6 +136,14 @@ describe('CategoryPostPage', () => {
       key: 'default',
     };
 
+    page = {
+      startPage: 1,
+      lastPage: 10,
+      currentLastPage: 11,
+    };
+
+    pageButton = [1, 2, 3, 4, 5];
+
     render(<CategoryPostsPage />);
   });
 
@@ -139,5 +161,17 @@ describe('CategoryPostPage', () => {
 
   it('render hit and post date', () => {
     screen.getByText('1 2022-11-22 100');
+  });
+
+  it('render page buttons', () => {
+    screen.getByText('1');
+    screen.getByText('2');
+    screen.getByText('3');
+    screen.getByText('4');
+    screen.getByText('5');
+  });
+
+  it('render next page button', () => {
+    screen.getByText('다음');
   });
 });

--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -19,20 +19,43 @@ export default function PostsPage() {
 
   const navigate = useNavigate();
 
+  const { pageNumber } = postStore;
+
   useEffect(() => {
-    postStore.fetchPosts();
+    postStore.fetchPosts(pageNumber);
     commentStore.fetchComments();
     commentStore.fetchRecomments();
     userStore.fetchUsers();
     likeStore.fetchLike();
     categoryStore.fetchCategory();
-  }, []);
+
+    postStore.makePage();
+  }, [pageNumber]);
+
+  const changePageNumber = (pageNubmer) => {
+    postStore.changePageNumber(pageNubmer);
+  };
+
+  const nextPage = () => {
+    postStore.nextPage();
+  };
+
+  const previousPage = () => {
+    postStore.previousPage();
+  };
 
   const { comments } = commentStore;
   const { recomments } = commentStore;
 
   const commentNumber = comments.map((comment) => comment.postId);
   const recommentNumber = recomments.map((recomment) => recomment.postId);
+
+  const { startPage } = postStore.page;
+  const { lastPage } = postStore.page;
+  const { currentLastPage } = postStore.page;
+
+  const isPreviousPage = startPage > 1;
+  const isNextPage = lastPage < currentLastPage;
 
   return (
     <Posts
@@ -43,6 +66,12 @@ export default function PostsPage() {
       users={userStore.users}
       categories={categoryStore.categories}
       navigate={navigate}
+      changePageNumber={changePageNumber}
+      nextPage={nextPage}
+      previousPage={previousPage}
+      pageButtons={postStore.pageButton}
+      isPreviousPage={isPreviousPage}
+      isNextPage={isNextPage}
     />
   );
 }

--- a/src/pages/PostsPage.test.jsx
+++ b/src/pages/PostsPage.test.jsx
@@ -10,6 +10,11 @@ const fetchCategory = jest.fn();
 const fetchLike = jest.fn();
 const navigate = jest.fn();
 
+const makePage = jest.fn();
+const changePageNumber = jest.fn();
+const nextPage = jest.fn();
+const previousPage = jest.fn();
+
 let posts = [];
 let likes = [];
 let users = [];
@@ -17,9 +22,18 @@ let categories = [];
 let comments = [];
 let recomments = [];
 
+let page = {};
+let pageButton = [];
+
 jest.mock('../hooks/usePostStore', () => () => ({
   fetchPosts,
+  makePage,
+  changePageNumber,
+  nextPage,
+  previousPage,
   posts,
+  page,
+  pageButton,
 }));
 
 jest.mock('../hooks/useCommentStore', () => () => ({
@@ -109,6 +123,13 @@ describe('postsPage', () => {
       },
     ];
 
+    page = {
+      startPage: 1,
+      lastPage: 10,
+      currentLastPage: 11,
+    };
+
+    pageButton = [1, 2, 3];
     render(<PostsPage />);
   });
 
@@ -130,5 +151,15 @@ describe('postsPage', () => {
 
   it('render category, Name', () => {
     screen.getByText('EPL / 굉민재');
+  });
+
+  it('render page buttons', () => {
+    screen.getByText('1');
+    screen.getByText('2');
+    screen.getByText('3');
+  });
+
+  it('render next page button', () => {
+    screen.getByText('다음');
   });
 });

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -6,10 +6,14 @@ import config from '../config';
 const baseUrl = config.apiBaseUrl;
 
 export default class PostApiService {
-  async fetchPosts() {
+  async fetchPosts(pageNumber) {
     const url = `${baseUrl}/posts`;
 
-    const { data } = await axios.get(url);
+    const { data } = await axios.get(url, {
+      params: {
+        page: pageNumber,
+      },
+    });
 
     return data;
   }
@@ -22,10 +26,14 @@ export default class PostApiService {
     return data;
   }
 
-  async fetchCategoryPosts(categoryId) {
+  async fetchCategoryPosts(categoryId, pageNumber) {
     const url = `${baseUrl}/category/${categoryId}`;
 
-    const { data } = await axios.get(url);
+    const { data } = await axios.get(url, {
+      params: {
+        page: pageNumber,
+      },
+    });
 
     return data;
   }

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -16,12 +16,21 @@ export default class PostStore extends Store {
     this.categoryId = '';
 
     this.imageUrl = '';
+
+    this.page = {};
+    this.pageNumber = 0;
+
+    this.pageButton = [];
   }
 
-  async fetchPosts() {
-    const data = await postApiService.fetchPosts();
+  async fetchPosts(pageNumber) {
+    const data = await postApiService.fetchPosts(pageNumber);
 
     this.posts = data.posts;
+
+    this.page = data.page;
+
+    this.makePage();
 
     this.publish();
   }
@@ -35,10 +44,14 @@ export default class PostStore extends Store {
     this.publish();
   }
 
-  async fetchCategoryPosts(categoryId) {
-    const data = await postApiService.fetchCategoryPosts(categoryId);
+  async fetchCategoryPosts(categoryId, pageNumber) {
+    const data = await postApiService.fetchCategoryPosts(categoryId, pageNumber);
 
     this.posts = data.posts;
+
+    this.page = data.page;
+
+    this.makePage();
 
     this.publish();
   }
@@ -62,6 +75,31 @@ export default class PostStore extends Store {
 
   changeCategory(categoryId) {
     this.categoryId = categoryId;
+
+    this.publish();
+  }
+
+  changePageNumber(pageNumber) {
+    this.pageNumber = pageNumber;
+
+    this.publish();
+  }
+
+  nextPage() {
+    this.pageNumber = this.page.lastPage;
+
+    this.publish();
+  }
+
+  previousPage() {
+    this.pageNumber = this.page.startPage - 11;
+
+    this.publish();
+  }
+
+  makePage() {
+    const pageButtons = [...Array(this.page.lastPage)].map((page, index) => index + 1);
+    this.pageButton = pageButtons.slice(this.page.startPage - 1, this.page.lastPage);
 
     this.publish();
   }

--- a/src/stores/PostStore.test.js
+++ b/src/stores/PostStore.test.js
@@ -23,6 +23,24 @@ describe('PostStore', () => {
         expect(posts.likes.length).toBe(1);
       });
     });
+
+    context('게시글이 10개가 넘어 페이지가 나뉘는 경우', () => {
+      beforeEach(async () => {
+        await postStore.fetchPosts();
+      });
+
+      it('게시글의 총 갯수를 확인할 수 있다.', async () => {
+        const { page } = postStore;
+
+        expect(page[0].totalPageNumber).toBe(21);
+      });
+
+      it('게시글의 마지막 페이지의 수를 확인할 수 있다.', () => {
+        const { page } = postStore;
+
+        expect(page[0].lastPage).toBe(3);
+      });
+    });
   });
 
   describe('writePost', () => {
@@ -51,6 +69,28 @@ describe('PostStore', () => {
         expect(postStore.post.content).toBe('카타르 월드컵 대한민국 16강 진출');
         expect(postStore.category.name).toBe('EPL');
         expect(postStore.post.hit).toBe(10);
+      });
+    });
+  });
+
+  describe('fetchCategoryPosts', () => {
+    context('특정 카테고리의 게시글만 불러올 경우', () => {
+      beforeEach(async () => {
+        await postStore.fetchCategoryPosts(3, 1);
+      });
+
+      it('게시글의 정보를 확인할 수 있다.', async () => {
+        const { posts } = postStore;
+
+        expect(posts[0].categories.name).toBe('LaLiga');
+        expect(posts[0].posts[0].title).toBe('이강인 라리가 베스트 일레븐');
+        expect(posts[0].posts[0].hit).toBe(10);
+      });
+
+      it('현재 페이지를 확인할 수 있다', () => {
+        const { page } = postStore;
+
+        expect(page[0].currentPageNumber).toBe(1);
       });
     });
   });

--- a/src/testServer.js
+++ b/src/testServer.js
@@ -56,7 +56,16 @@ const server = setupServer(
           },
         ],
       },
+    ],
 
+    page: [
+      {
+        currentLastPage: 3,
+        currentPageNumber: 1,
+        lastPage: 3,
+        startPage: 1,
+        totalPageNumber: 21,
+      },
     ],
   }))),
 
@@ -182,6 +191,61 @@ const server = setupServer(
         id: 1,
         name: 'EPL',
         parentId: 1,
+      },
+    ],
+  }))),
+
+  rest.get(`${baseUrl}/category/3`, async (req, res, ctx) => res(ctx.json({
+    posts: [
+      {
+        categories: {
+          id: 3,
+          name: 'LaLiga',
+        },
+        comments: [
+          {
+            id: 1,
+            content: '1번째 게시글의 댓글',
+            userId: 1,
+            postId: 10,
+            commentDate: '2022-11-01',
+          },
+        ],
+        likes: [
+          {
+            id: 2,
+            postId: 10,
+            userId: 1,
+          },
+        ],
+        posts: [
+          {
+            id: 10,
+            title: '이강인 라리가 베스트 일레븐',
+            categoryId: 3,
+            hit: 10,
+            imageUrl: 'imageUrl',
+            userId: 1,
+          },
+        ],
+        users: [
+          {
+            id: 1,
+            identification: 'Pikachu',
+            name: 'Lee',
+            profileImage: 'profileImage',
+          },
+        ],
+      },
+    ],
+
+    page: [
+      {
+        currentLastPage: 6,
+        currentPageNumber: 1,
+        lastPage: 6,
+        startPage: 1,
+        totalPageNumber: 11,
       },
     ],
   }))),


### PR DESCRIPTION
- 현재 페이지를 백엔드에 요청해 시작 페이지, 마지막 페이지, 현재 화면의 마지막 페이지를 받아와 페이지네이션 구현
- 전체 게시판과 카테고리 게시판 페이지 네이션 구현
- 카테고리 게시판 2페이지에서 다른 카테고리 게시판으로 이동해 해당 게시판의 게시글을 요청할때 2페이지를 넘겨주던 오류 해결